### PR TITLE
Enemy lifecycle changes

### DIFF
--- a/Assets/Prefabs/Debris.prefab
+++ b/Assets/Prefabs/Debris.prefab
@@ -1,0 +1,121 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4395591764634758786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4395591764634758791}
+  - component: {fileID: 4395591764634758788}
+  - component: {fileID: 3867854809940633787}
+  - component: {fileID: 1009149968663077566}
+  m_Layer: 0
+  m_Name: Debris
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4395591764634758791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395591764634758786}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4395591764634758788
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395591764634758786}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: ffc8f6cbc65c2e14694e19caff53a80b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.01, y: 0.01}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &3867854809940633787
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395591764634758786}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
+--- !u!114 &1009149968663077566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395591764634758786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 490b949ed093b3745a2daf1cf77eb5d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Debris.prefab.meta
+++ b/Assets/Prefabs/Debris.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6884334da442b4c4296f325b9b896c61
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -154,6 +154,7 @@ MonoBehaviour:
   - {fileID: 1169755782, guid: 40f18e32d89d3444c8ba6183a9131bc3, type: 3}
   - {fileID: -321455076, guid: 6e8722eec164a2045b36c9bf292d1b24, type: 3}
   - {fileID: 1763515217, guid: 6377fe0bdc0d1dd469bb5c068a55811a, type: 3}
+  DebrisPrefab: {fileID: 4395591764634758786, guid: 6884334da442b4c4296f325b9b896c61, type: 3}
 --- !u!95 &6232591748759594082
 Animator:
   serializedVersion: 5

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -291,76 +291,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1001 &153562060
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 2043173320}
-    m_Modifications:
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.24581724
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.24
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: type
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_Name
-      value: Enemy (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
---- !u!4 &153562061 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-  m_PrefabInstance: {fileID: 153562060}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &163483946
 GameObject:
   m_ObjectHideFlags: 0
@@ -720,6 +650,76 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &505415897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1188524196}
+    m_Modifications:
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.24581724
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_Name
+      value: Enemy (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+--- !u!4 &505415898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+  m_PrefabInstance: {fileID: 505415897}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -818,24 +818,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Player: {fileID: 971181774}
---- !u!1001 &551102078
+--- !u!1001 &535692660
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2043173320}
+    m_TransformParent: {fileID: 1188524196}
     m_Modifications:
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.75
+      value: -0.24581724
       objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.84
+      value: 5.34
       objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_LocalPosition.z
@@ -869,10 +869,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: type
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_Name
       value: Enemy
@@ -883,10 +879,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
---- !u!4 &551102079 stripped
+--- !u!4 &535692661 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-  m_PrefabInstance: {fileID: 551102078}
+  m_PrefabInstance: {fileID: 535692660}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &631122530
 GameObject:
@@ -1004,6 +1000,7 @@ Transform:
   - {fileID: 971181774}
   - {fileID: 2098476540}
   - {fileID: 2043173320}
+  - {fileID: 1188524196}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1259,6 +1256,76 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &936081431
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1188524196}
+    m_Modifications:
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_Name
+      value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+--- !u!4 &936081432 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+  m_PrefabInstance: {fileID: 936081431}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &946606233
 GameObject:
   m_ObjectHideFlags: 0
@@ -1601,6 +1668,42 @@ Transform:
   m_Father: {fileID: 1561650589}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1188524195
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1188524196}
+  m_Layer: 0
+  m_Name: DebrisContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1188524196
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1188524195}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 535692661}
+  - {fileID: 936081432}
+  - {fileID: 505415898}
+  - {fileID: 1456600637}
+  - {fileID: 1488848509}
+  m_Father: {fileID: 634200340}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1201198914
 GameObject:
   m_ObjectHideFlags: 0
@@ -1868,12 +1971,82 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1001 &1398347211
+--- !u!1001 &1456600636
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2043173320}
+    m_TransformParent: {fileID: 1188524196}
+    m_Modifications:
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: type
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_Name
+      value: Enemy (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+--- !u!4 &1456600637 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+  m_PrefabInstance: {fileID: 1456600636}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1488848508
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1188524196}
     m_Modifications:
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_RootOrder
@@ -1933,10 +2106,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
---- !u!4 &1398347212 stripped
+--- !u!4 &1488848509 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-  m_PrefabInstance: {fileID: 1398347211}
+  m_PrefabInstance: {fileID: 1488848508}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1560914061
 GameObject:
@@ -2209,76 +2382,6 @@ Transform:
   m_Father: {fileID: 1561650589}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1955404831
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 2043173320}
-    m_Modifications:
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.81
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.81
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594083, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: type
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_Name
-      value: Enemy (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
---- !u!4 &1955404832 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
-  m_PrefabInstance: {fileID: 1955404831}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1987197013
 GameObject:
   m_ObjectHideFlags: 0
@@ -2392,10 +2495,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 953953657}
-  - {fileID: 551102079}
-  - {fileID: 153562061}
-  - {fileID: 1955404832}
-  - {fileID: 1398347212}
   m_Father: {fileID: 634200340}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -350,6 +350,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Enemy (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
 --- !u!4 &153562061 stripped
@@ -872,6 +876,10 @@ PrefabInstance:
     - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_Name
       value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
@@ -1689,6 +1697,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c45be022689aa814793684c161419fc4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  EnemyPrefab: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+  EnemyContainer: {fileID: 2043173319}
+  Player: {fileID: 971181771}
 --- !u!1 &1369688081
 GameObject:
   m_ObjectHideFlags: 0
@@ -1915,6 +1926,10 @@ PrefabInstance:
     - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_Name
       value: Enemy (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
@@ -2253,6 +2268,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Enemy (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
 --- !u!4 &1955404832 stripped
@@ -2428,7 +2447,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.84
+      value: 5.34
       objectReference: {fileID: 0}
     - target: {fileID: 6232591748759594080, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2465,6 +2484,10 @@ PrefabInstance:
     - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
       propertyPath: m_Name
       value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232591748759594092, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28e3236ac2921fb4eae47fc8de6cf408, type: 3}

--- a/Assets/Scripts/Debris.cs
+++ b/Assets/Scripts/Debris.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Debris : MonoBehaviour
+{
+    float lifeTimer = 1f;
+
+    void Awake()
+    {
+        Init();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        lifeTimer -= Time.deltaTime;
+        if (lifeTimer < 0)
+        {
+            Destroy(this.gameObject);
+        }
+    }
+
+    public void Init()
+    {
+        lifeTimer = Random.Range(.1f, .5f);
+        float randVal = Random.Range(0, 100f);
+        Color newColor = Color.white;
+        if (randVal < 25f)
+            newColor = new Color(255f/255f, 233f/255f, 127f/255f); // light yello
+        else if (randVal < 50f)
+            newColor = Color.yellow;
+        else if (randVal < 75f)
+            newColor = new Color(255f/255f, 178f/255f, 127f/255f); // light orange
+        this.GetComponent<SpriteRenderer>().color = newColor;
+        float randomAngle = Random.Range(0f, 360f);
+        Vector2 normalizedPos = new Vector2(Mathf.Cos(randomAngle), Mathf.Sin(randomAngle));
+        Vector2 scaledNormalizedPos = normalizedPos * Random.Range (2.0f, 4.0f);
+        float newScale = Random.Range(1f, 3f);
+        this.transform.localScale = new Vector2(newScale, newScale);
+        this.GetComponent<Rigidbody2D>().velocity = scaledNormalizedPos;
+
+    }
+
+}

--- a/Assets/Scripts/Debris.cs.meta
+++ b/Assets/Scripts/Debris.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 490b949ed093b3745a2daf1cf77eb5d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -27,18 +27,16 @@ public class Enemy : MonoBehaviour
     float positionTimerMax = .5f;
 
     // Start is called before the first frame update
-    void Start()
+    void Awake()
     {
         playerTransform = GameObject.Find("Player").transform;
         enemyAnimator = GetComponent<Animator>();
         enemyCollider = GetComponent<BoxCollider2D>();
         enemyRigidbody = GetComponent<Rigidbody2D>();
         enemyRenderer = GetComponent<SpriteRenderer>();
-
-        ConfigureEnemy(type);
     }
 
-    void ConfigureEnemy(Globals.EnemyTypes newType)
+    public void ConfigureEnemy(Globals.EnemyTypes newType)
     {
         type = newType;
         enemyRenderer.sprite = EnemySprites[(int)type];

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -26,6 +26,9 @@ public class Enemy : MonoBehaviour
     float positionTimer = .1f;
     float positionTimerMax = .5f;
 
+    float flashTimer = 0f;
+    float flashTimerMax = .15f;
+
     // Start is called before the first frame update
     void Awake()
     {
@@ -103,6 +106,12 @@ public class Enemy : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        handleMovement();
+        handleFlash();
+    }
+
+    private void handleMovement()
+    {
         if (positionTimer > 0)
         {
             positionTimer -= Time.deltaTime;
@@ -120,6 +129,18 @@ public class Enemy : MonoBehaviour
         enemyRigidbody.velocity = movementVector;
     }
 
+    private void handleFlash()
+    {
+        if (flashTimer > 0)
+        {
+            flashTimer -= Time.deltaTime;
+            if (flashTimer < 0)
+            {
+                enemyRenderer.color = Color.white;
+            }
+        }
+    }
+
     void OnTriggerEnter2D(Collider2D collider)
     {
         Bullet bullet = collider.gameObject.GetComponent<Bullet>();
@@ -127,7 +148,9 @@ public class Enemy : MonoBehaviour
         {
             life = life - 1f;
             if (life <= 0)
-                KillEnemy(collider);
+                KillEnemy();
+            else
+                DamageEnemy();
             Destroy(bullet.gameObject);
         }
         Player player = collider.gameObject.GetComponent<Player>();
@@ -137,10 +160,16 @@ public class Enemy : MonoBehaviour
         }
     }
 
-    public void KillEnemy(Collider2D collider)
+    public void KillEnemy()
     {
         this.GetComponent<Collider2D>().enabled = false;
         isActive = false;
         Destroy(this.gameObject);
+    }
+
+    void DamageEnemy()
+    {
+        enemyRenderer.color = new Color(87f/255f, 87f/255f, 87f/255f);
+        flashTimer = flashTimerMax;
     }
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -29,10 +29,15 @@ public class Enemy : MonoBehaviour
     float flashTimer = 0f;
     float flashTimerMax = .15f;
 
+    [SerializeField]
+    GameObject DebrisPrefab;
+    GameObject debrisContainer;
+
     // Start is called before the first frame update
     void Awake()
     {
         playerTransform = GameObject.Find("Player").transform;
+        debrisContainer = GameObject.Find("DebrisContainer");
         enemyAnimator = GetComponent<Animator>();
         enemyCollider = GetComponent<BoxCollider2D>();
         enemyRigidbody = GetComponent<Rigidbody2D>();
@@ -162,6 +167,13 @@ public class Enemy : MonoBehaviour
 
     public void KillEnemy()
     {
+        int numDebris = Random.Range(8, 10);
+        for (int x = 0; x < numDebris; x++)
+        {
+            GameObject debrisGO = Instantiate(DebrisPrefab, this.transform.localPosition, Quaternion.identity, debrisContainer.transform);
+            debrisGO.GetComponent<Debris>().Init();
+        }
+
         this.GetComponent<Collider2D>().enabled = false;
         isActive = false;
         Destroy(this.gameObject);

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -20,6 +20,9 @@ public class Enemy : MonoBehaviour
     private Rigidbody2D enemyRigidbody;
     float moveSpeed = .5f;
     Vector2 movementVector = new Vector2(0, 0);
+    Vector2 impactVector = new Vector2(0, 0);
+    float impactTimer = 0f;
+    float impactTimerMax = .1f;
     bool flipWithMovement = false;
 
     Transform playerTransform;
@@ -113,6 +116,7 @@ public class Enemy : MonoBehaviour
     {
         handleMovement();
         handleFlash();
+        handleImpact();
     }
 
     private void handleMovement()
@@ -131,7 +135,7 @@ public class Enemy : MonoBehaviour
             if ((movementVector.x >= 0 && this.transform.localScale.x < 0) || (movementVector.x < 0 && this.transform.localScale.x > 0))
                 this.transform.localScale = new Vector3(this.transform.localScale.x * -1, this.transform.localScale.y, this.transform.localScale.z);
         }
-        enemyRigidbody.velocity = movementVector;
+        enemyRigidbody.velocity = impactTimer > 0 ? impactVector : movementVector;
     }
 
     private void handleFlash()
@@ -146,6 +150,14 @@ public class Enemy : MonoBehaviour
         }
     }
 
+    private void handleImpact()
+    {
+        if (impactTimer > 0)
+        {
+            impactTimer -= Time.deltaTime;
+        }
+    }
+
     void OnTriggerEnter2D(Collider2D collider)
     {
         Bullet bullet = collider.gameObject.GetComponent<Bullet>();
@@ -155,9 +167,10 @@ public class Enemy : MonoBehaviour
             if (life <= 0)
                 KillEnemy();
             else
-                DamageEnemy();
+                DamageEnemy(collider.gameObject.GetComponent<Rigidbody2D>().velocity);
             Destroy(bullet.gameObject);
         }
+
         Player player = collider.gameObject.GetComponent<Player>();
         if (player != null && isActive)
         {
@@ -179,9 +192,11 @@ public class Enemy : MonoBehaviour
         Destroy(this.gameObject);
     }
 
-    void DamageEnemy()
+    void DamageEnemy(Vector2 impactVelocity)
     {
         enemyRenderer.color = new Color(87f/255f, 87f/255f, 87f/255f);
         flashTimer = flashTimerMax;
+        impactVector = new Vector2(impactVelocity.x * .5f, impactVelocity.y * .5f);
+        impactTimer = impactTimerMax;
     }
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -130,6 +130,7 @@ public class Enemy : MonoBehaviour
             life = life - 1f;
             if (life <= 0)
                 KillEnemy(collider);
+            Destroy(bullet.gameObject);
         }
         Player player = collider.gameObject.GetComponent<Player>();
         if (player != null && isActive)

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -37,8 +37,11 @@ public class Player : MonoBehaviour
     bool isMoving = false;
     Animator playerAnimator;
 
-    float shootTimer = .5f;
-    float shootTimerMax = .25f;
+    float shootTimer = 1f;
+    float shootTimerBurstMax = .25f;
+    float shootTimerMax = 1.5f;
+    int burstNum = 4;
+    int burstNumMax = 3;
     float muzzleFlashTimer = 0f;
     float muzzleFlashTimerMax = .05f;
 
@@ -152,7 +155,9 @@ public class Player : MonoBehaviour
                     ? -10f
                     : 0;
             bulletRigidbody.velocity = new Vector2(xMovement, yMovement);
-            shootTimer = shootTimerMax;
+            burstNum = burstNum - 1;
+            shootTimer = burstNum == 0 ? shootTimerMax : shootTimerBurstMax;
+            if (burstNum == 0) burstNum = burstNumMax;
 
             MuzzleGO.SetActive(true);
             muzzleFlashTimer = muzzleFlashTimerMax;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -185,7 +185,6 @@ public class Player : MonoBehaviour
         }
     }
 
-
     public void HitPlayer(float damage)
     {
         if (invincibleTimer <= 0)

--- a/Assets/Scripts/SceneManager.cs
+++ b/Assets/Scripts/SceneManager.cs
@@ -41,6 +41,15 @@ public class SceneManager : MonoBehaviour
             Vector2 playerPos = Player.transform.localPosition;
             Vector2 enemyPos = new Vector2(playerPos.x + normalizedPos.x * Random.Range(4.5f, 7.5f), playerPos.y + normalizedPos.y * Random.Range(5.5f, 7.5f));
             GameObject enemyGO = Instantiate(EnemyPrefab, enemyPos, Quaternion.identity, EnemyContainer.transform);
+            Globals.EnemyTypes enemyType = Globals.EnemyTypes.Yar;
+            float randVal = Random.Range(0, 100f);
+            if (randVal > 95f)
+                enemyType = Globals.EnemyTypes.Qbert;
+            else if (randVal > 90f)
+                enemyType = Globals.EnemyTypes.MsPac;
+            else if (randVal > 80f)
+                enemyType = Globals.EnemyTypes.Pac;
+            enemyGO.GetComponent<Enemy>().ConfigureEnemy(enemyType);
         }
     }
 }

--- a/Assets/Scripts/SceneManager.cs
+++ b/Assets/Scripts/SceneManager.cs
@@ -4,15 +4,43 @@ using UnityEngine;
 
 public class SceneManager : MonoBehaviour
 {
+    [SerializeField]
+    GameObject EnemyPrefab;
+    [SerializeField]
+    GameObject EnemyContainer;
+
+    [SerializeField]
+    GameObject Player;
+
+    float spawnTimer = 5f;
+    float spawnTimerMax = 5f;
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        SpawnEnemies(20);
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        spawnTimer -= Time.deltaTime;
+        if (spawnTimer <= 0)
+        {
+            spawnTimer = spawnTimerMax;
+            SpawnEnemies(10);
+        }
+    }
+
+    void SpawnEnemies(int num)
+    {
+        for (int x = 0; x < num; x++)
+        {
+            float randomAngle = Random.Range(0f, 360f);
+            Vector2 normalizedPos = new Vector2(Mathf.Cos(randomAngle), Mathf.Sin(randomAngle));
+            Vector2 playerPos = Player.transform.localPosition;
+            Vector2 enemyPos = new Vector2(playerPos.x + normalizedPos.x * Random.Range(4.5f, 7.5f), playerPos.y + normalizedPos.y * Random.Range(5.5f, 7.5f));
+            GameObject enemyGO = Instantiate(EnemyPrefab, enemyPos, Quaternion.identity, EnemyContainer.transform);
+        }
     }
 }

--- a/Assets/Scripts/SceneManager.cs
+++ b/Assets/Scripts/SceneManager.cs
@@ -38,8 +38,9 @@ public class SceneManager : MonoBehaviour
         {
             float randomAngle = Random.Range(0f, 360f);
             Vector2 normalizedPos = new Vector2(Mathf.Cos(randomAngle), Mathf.Sin(randomAngle));
+            Vector2 scaledNormalizedPos = normalizedPos * Random.Range (7.0f, 9.0f);
             Vector2 playerPos = Player.transform.localPosition;
-            Vector2 enemyPos = new Vector2(playerPos.x + normalizedPos.x * Random.Range(4.5f, 7.5f), playerPos.y + normalizedPos.y * Random.Range(5.5f, 7.5f));
+            Vector2 enemyPos = new Vector2(playerPos.x + scaledNormalizedPos.x, playerPos.y + scaledNormalizedPos.y);
             GameObject enemyGO = Instantiate(EnemyPrefab, enemyPos, Quaternion.identity, EnemyContainer.transform);
             Globals.EnemyTypes enemyType = Globals.EnemyTypes.Yar;
             float randVal = Random.Range(0, 100f);


### PR DESCRIPTION
Add changes to enemy behavior and lifecycle.  Includes the following:
- Destroy bullets when they hit enemy.
- Change bullet creation timing (add bursts).
- Add enemy spawn timer, spawn enemy type based on random number generation.
- Add enemy type configuration.
- Make enemy flash for short time when hit to better indicate damage.
- Improve enemy start positions.  Generate random angle from 0 to 360. Use sin and cos to get x and y values on unit circle.  Scale these values so enemy is spawned offscreen.
- Add debris prefab that is instantiated when enemy is killed (between 8 and 10).
- Add impact velocity to enemy when hit by bullet.